### PR TITLE
WIP Create an undoManager if none exists

### DIFF
--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -134,11 +134,11 @@ NSString* BSManagedDocumentDidSaveNotification = @"BSManagedDocumentDidSaveNotif
 #if !__has_feature(objc_arc)
         [undoManager release];
 #endif
+        if (self.hasUndoManager) {
+            [NSNotificationCenter.defaultCenter removeObserver:self name:nil object:self.undoManager];
+        }
     }
 
-    if (self.undoManager) {
-        [NSNotificationCenter.defaultCenter removeObserver:self name:nil object:self.undoManager];
-    }
     self.undoManager = context.undoManager;
 
     // Need 10.7+ to support parent context

--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -136,6 +136,9 @@ NSString* BSManagedDocumentDidSaveNotification = @"BSManagedDocumentDidSaveNotif
 #endif
     }
 
+    if (self.undoManager) {
+        [NSNotificationCenter.defaultCenter removeObserver:self name:nil object:self.undoManager];
+    }
     self.undoManager = context.undoManager;
 
     // Need 10.7+ to support parent context

--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -125,6 +125,19 @@ NSString* BSManagedDocumentDidSaveNotification = @"BSManagedDocumentDidSaveNotif
 
     NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
     
+    // 10.12 stopped creating undoManagers for us automatically
+    // https://github.com/karelia/BSManagedDocument/issues/47
+    // https://github.com/karelia/BSManagedDocument/issues/50
+    if (context != nil && context.undoManager == nil) {
+        NSUndoManager *undoManager = [[NSUndoManager alloc] init];
+        context.undoManager = undoManager;
+#if !__has_feature(objc_arc)
+        [undoManager release];
+#endif
+    }
+
+    self.undoManager = context.undoManager;
+
     // Need 10.7+ to support parent context
     if ([context respondsToSelector:@selector(setParentContext:)])
     {


### PR DESCRIPTION
10.12 stopped creating undo managers for MOCs automatically.

Before the @jerrykrinock commits, the karelia code stopped the document from receiving a non-MOC undoManager by overriding `setUndoManager:` to be a no-op. Now, the setter acts as expected, and the document receives its default undoManager from AppKit, but then this manager is soon replaced with the MOC's undoManager during `setManagedObjectContext:`.

Comments from @theMikeSwan indicate that calls to `.undoManager` cause a crash in 10.14 (maybe need to be wrapped in `performBlockAndWait:`?) but I have not seen these crashes anywhere.