### PR TITLE
Fix warning when closing / deleting unsaved document

### DIFF
--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -347,7 +347,10 @@ NSString* BSManagedDocumentDidSaveNotification = @"BSManagedDocumentDidSaveNotif
 - (BOOL)removePersistentStoreWithError:(NSError **)outError {
     NSManagedObjectContext *context = self.managedObjectContext;
     __block BOOL result = YES;
-    __block NSError * error = nil ;
+    __block NSError * error = nil;
+    if (!_store)
+        return YES;
+
     if ([context respondsToSelector:@selector(parentContext)])
     {
         // In my testing, HAVE to do the removal using parent's private queue. Otherwise, it deadlocks, trying to acquire a _PFLock


### PR DESCRIPTION
New (un-autosaved) documents don't yet have a `_store`, so attempting to remove the persistent store coordinator upon document close results in an error, which gets `NSLog`'ged.

Return success from `removePersistentStoreWithError:` when `_store` is nil, because there is
nothing to remove.