### PR TITLE
Require Mountain Lion

### DIFF
--- a/BSManagedDocument.h
+++ b/BSManagedDocument.h
@@ -57,6 +57,7 @@ extern NSString* BSManagedDocumentErrorDomain ;
 
 typedef BOOL (^WritingBlockType) (NSURL*, NSSaveOperationType, NSURL*, NSError**);
 
+API_AVAILABLE(macos(10.8))
 __attribute__((visibility("default"))) @interface BSManagedDocument : NSDocument
 {
   @private  // still targeting legacy runtime, so YES, I need to declare the ivars


### PR DESCRIPTION
Rip out ancient code paths to make the code more intelligible, and bid a fond farewell to Snow Leopard and Lion. Also use properties in a couple more places.

This removes about 100 lines of code (net). No change in application behavior is intended.