### PR TITLE
Fix compliation in ARC environment

### DIFF
--- a/BSManagedDocument.m
+++ b/BSManagedDocument.m
@@ -1059,7 +1059,9 @@ originalContentsURL:(NSURL *)originalContentsURL
             dispatch_semaphore_signal(semaphore);
         }];
         dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
+#if ! __has_feature(objc_arc)
         dispatch_release(semaphore);
+#endif
     }
 }
 


### PR DESCRIPTION
I use BSManagedDocument with the default ARC compilation flag but haven't updated it in a while. 
Thank you for keeping it alive.
I downloaded the latest today and noticed that it doesn't compile in ARC mode, so here's the simple fix.